### PR TITLE
Fix for npm support

### DIFF
--- a/src/Ratio.js
+++ b/src/Ratio.js
@@ -785,7 +785,8 @@ Ratio.prototype.toQuantityOf = function () {
 // Adds npm support
 if (typeof exports !== 'undefined') {
 	if (typeof module !== 'undefined' && module.exports) {
-		exports = module.exports;
+		module.exports = Ratio;
+	} else {
+		exports.Ratio = Ratio;
 	}
-	exports = Ratio;
 }


### PR DESCRIPTION
In order to export a single object, `module.exports` must be set directly.

Assigning it to a different variable and writing to it wouldn't work (as there are no pointers in JavaScript).

In environments who doesn't have the `module` object, the only way is to assign the module to a property of the `exports` object.
